### PR TITLE
Faq section lag fix

### DIFF
--- a/assets/css/overrides.scss
+++ b/assets/css/overrides.scss
@@ -3,6 +3,13 @@ html, body, #__nuxt, #__layout, #app {
   height: 100%;
 }
 
+// FAQ-section lag fix
+
+.mb-5, .my-5 {
+  margin-bottom: unset !important;
+  padding-bottom: 10px;
+  }
+
 @media (min-width: 1200px) {
   .container, .container-sm, .container-md, .container-lg, .container-xl {
       max-width: 1400px;


### PR DESCRIPTION
Stuttering in faq page was due to `.mb-5` class  in bootstrap-vue having a margin, that made the animation calculation stutter.
Added rule `overrides.scss`:

`margin-bottom` is now `unset`
`padding-bottom` added at `10px`